### PR TITLE
feat: hosting bootstrap + landing page for pastickfight

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "pastickfight"
+  }
+}

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -1,0 +1,27 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PASTICKFIGHT }}
+          projectId: pastickfight
+          channelId: ${{ github.event_name == 'push' && 'live' || '' }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # pastickfight
+
+# Hosting & Deploys
+
+This repo deploys to **https://pastickfight.web.app**.
+
+## CI/CD
+- **PRs** → Preview channel link (posted by the Action as a PR comment).
+- **Push to `main`** → Live deploy to pastickfight.web.app.
+
+### Secrets required (one-time)
+Create a GitHub Action secret named **`FIREBASE_SERVICE_ACCOUNT_PASTICKFIGHT`** that contains a JSON key for a service account with **Firebase Hosting Admin** (and optionally **Firebase Admin**) roles. See “Secrets setup” below.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,14 @@
+{
+  "hosting": {
+    "site": "pastickfight",
+    "public": "public",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [{ "source": "**", "destination": "/index.html" }],
+    "headers": [
+      {
+        "source": "/assets/**",
+        "headers": [{ "key": "Cache-Control", "value": "public, max-age=3600" }]
+      }
+    ]
+  }
+}

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,3 @@
+<!doctype html><meta charset="utf-8"><title>Not Found</title>
+<style>body{font-family:system-ui;margin:2rem;color:#333}</style>
+<h1>404</h1><p>This route doesn’t exist. <a href="/">Back to home</a>.</p>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Pigeon Army — Stick Fight</title>
+  <meta name="description" content="Pigeon Army: Stick Fight — hosted on Firebase">
+  <style>
+    :root { --bg:#0f1224; --fg:#e8ecff; --muted:#9aa3c7; }
+    * { box-sizing: border-box; }
+    html,body { height:100%; margin:0; }
+    body {
+      display:grid; place-items:center; background:radial-gradient(1100px 520px at 50% -10%, #1b2050, var(--bg));
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      color:var(--fg);
+    }
+    .card { width: min(720px, 92vw); padding:28px 32px; border-radius:16px; border:1px solid rgba(255,255,255,.12);
+      background: rgba(255,255,255,.04); backdrop-filter: blur(6px); text-align:center; }
+    h1 { margin: 10px 0 8px; font-size: clamp(26px, 6vw, 40px); letter-spacing:.4px; }
+    p.sub { margin:0 0 16px; color: var(--muted); }
+    .row { display:flex; gap:10px; justify-content:center; flex-wrap:wrap; margin-top:12px; }
+    a.btn { text-decoration:none; color:var(--fg); border:1px solid rgba(255,255,255,.15); padding:10px 14px; border-radius:12px; }
+    .mono { margin-top:10px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:12px; opacity:.9 }
+    .pill { display:inline-block; padding:5px 9px; border:1px solid rgba(255,255,255,.15); border-radius:999px; font-size:12px; color:var(--muted) }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="pill">Firebase Hosting — pastickfight</div>
+    <h1>Pigeon Army: Stick Fight</h1>
+    <p class="sub">Landing page is live. Game build coming soon.</p>
+    <div class="row">
+      <a class="btn" href="/">Lobby</a>
+      <a class="btn" href="/admin">Admin</a>
+      <a class="btn" href="/play/TEST123">Play (test route)</a>
+    </div>
+    <p class="mono" id="status">[Firebase] initializing…</p>
+  </div>
+
+  <!-- Firebase SDK (modular v9; CDN) — "Firebase SDK: pastickfight"  -->
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyAjOFxyff5GFyEwHgUBQqJ9Jxl0cjcpNaY",
+      authDomain: "pastickfight.firebaseapp.com",
+      projectId: "pastickfight",
+      storageBucket: "pastickfight.firebasestorage.app",
+      messagingSenderId: "511257741114",
+      appId: "1:511257741114:web:7595bd00ac209d0a44f203"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    console.log("[Firebase] initialized:", app.name);
+    const el = document.getElementById("status");
+    if (el) el.textContent = "[Firebase] initialized ✓ " + app.name;
+  </script>
+</body>
+</html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
## Summary
- Created .firebaserc and firebase.json with "site": "pastickfight"
- Added GitHub Action (.github/workflows/firebase-hosting.yml)
- Added landing page at /public/index.html using saved Firebase SDK config
- ✅ After secret is added, PR will show a Preview URL; merging to main deploys live

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc856338b4832e9f2e2f1116fdd736