### PR TITLE
feat: minimal Main/Lobby/Admin pages + live deploy workflow (no checks)

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -1,0 +1,25 @@
+name: Firebase Hosting (live)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Deploy straight to the live channel on push to main.
+      # No repoToken => no GitHub Checks/PR comments (avoids 403).
+      - name: Deploy to Firebase Hosting (live)
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PASTICKFIGHT }}
+          projectId: pastickfight
+          channelId: live

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,10 +1,2 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Admin</title>
-</head>
-<body>
-  <h1>Admin Page</h1>
-</body>
-</html>
+<!doctype html>
+<h1>Admin Page</h1>

--- a/public/index.html
+++ b/public/index.html
@@ -1,10 +1,2 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Main Page</title>
-  </head>
-  <body>
-    <h1>Main Page</h1>
-  </body>
-</html>
+<!doctype html>
+<h1>Main Page</h1>

--- a/public/lobby/index.html
+++ b/public/lobby/index.html
@@ -1,11 +1,2 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Lobby</title>
-</head>
-<body>
-  <h1>Lobby Page</h1>
-</body>
-</html>
+<!doctype html>
+<h1>Lobby Page</h1>


### PR DESCRIPTION
## Summary
- add a Firebase Hosting workflow that deploys pushes to main straight to the live channel without GitHub Checks
- reduce the Main, Lobby, and Admin pages to title-only static HTML so each path serves its own file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc921682a4832eb88bd4d20d489178