### PR TITLE
ci: switch preflight to file, target projectId pastickfight-472521, deploy + verify

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -1,4 +1,4 @@
-name: Firebase Hosting (live + verify)
+name: Firebase Hosting (live + preflight-file)
 
 on:
   push:
@@ -15,19 +15,54 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Preflight: print safe fields from the secret to ensure it belongs to this project
-      - name: Secret preflight (safe fields)
+      # A) Write a preflight script to disk (avoids inline-quote/log mangling)
+      - name: Write preflight script
+        run: |
+          mkdir -p .github/scripts
+          cat > .github/scripts/preflight.js <<'JS'
+          (() => {
+            const s = process.env.SA_JSON;
+            if (!s) {
+              console.error("::error::Missing secret FIREBASE_SERVICE_ACCOUNT_PASTICKFIGHT");
+              process.exit(1);
+            }
+            let j;
+            try { j = JSON.parse(s); }
+            catch (e) {
+              console.error("::error::Secret is not valid JSON: " + e.message);
+              process.exit(1);
+            }
+            const pid = j.project_id || "";
+            const email = j.client_email || "";
+            const domain = email.includes("@") ? email.split("@")[1] : "";
+            console.log(`project_id=${pid}`);
+            console.log(`client_email_domain=${domain}`);
+            if (pid !== "pastickfight-472521") {
+              console.error("::error::Secret project_id must be 'pastickfight-472521'");
+              process.exit(1);
+            }
+          })();
+          JS
+
+      - name: Preflight — secret sanity
+        env:
+          SA_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PASTICKFIGHT }}
+        run: node .github/scripts/preflight.js
+
+      # B) Permission probe using the SA as ADC (no prompts)
+      - name: Preflight — permission probe
+        shell: bash
         env:
           SA_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PASTICKFIGHT }}
         run: |
-          node -e '(() => {
-            if (!process.env.SA_JSON) { console.error("::error::Missing secret FIREBASE_SERVICE_ACCOUNT_PASTICKFIGHT"); process.exit(1); }
-            let j; try { j = JSON.parse(process.env.SA_JSON); } catch { console.error("::error::Secret is not valid JSON"); process.exit(1); }
-            console.log(`project_id=${j.project_id}`); 
-            console.log(`client_email_domain=${(j.client_email||"").split("@")[1]||""});
-            if (j.project_id !== "pastickfight-472521") { console.error("::error::Secret project_id must be pastickfight-472521"); process.exit(1); }
-          })()'
+          set -euo pipefail
+          echo "$SA_JSON" > "$RUNNER_TEMP/sa.json"
+          export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/sa.json"
+          npx --yes firebase-tools@latest --non-interactive projects:list --project pastickfight-472521 1>/dev/null
+          npx --yes firebase-tools@latest --non-interactive hosting:sites:list --project pastickfight-472521 1>/dev/null
+          echo "✅ Permission probe passed."
 
+      # C) Deploy live (no repoToken => no Checks API)
       - name: Deploy to Firebase Hosting (live)
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
@@ -35,7 +70,9 @@ jobs:
           projectId: pastickfight-472521
           channelId: live
 
+      # D) Verify live pages
       - name: Verify live pages
+        shell: bash
         run: |
           set -euo pipefail
           base="https://pastickfight-472521.web.app"
@@ -43,7 +80,7 @@ jobs:
           for p in "${!pages[@]}"; do
             url="${base}/${p}"
             exp="${pages[$p]}"
-            echo "Checking $url contains: $exp"
+            echo "Checking $url for: $exp"
             html="$(curl -fsSL --retry 4 --retry-connrefused --max-time 20 "$url")"
             echo "$html" | grep -q "$exp" || { echo "::error::Expected '$exp' not found at $url"; exit 1; }
           done


### PR DESCRIPTION
## Summary
- replace the inline node -e preflight with a checked-in script file written during the workflow
- enforce the pastickfight-472521 project id for all firebase CLI actions
- verify live hosting pages after deployment

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cca2fe3b48832e812a0aacf20706d3