### PR TITLE
Add admin player management and lobby code gate

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -95,6 +95,6 @@ jobs:
 
           check "${base}/" "Main Page"
           check "${base}/lobby" "Lobby Page"
-          check "${base}/admin" "Admin Page"
+          check "${base}/admin" "Admin — Players"
 
           echo "✅ Verified all pages."

--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -1,0 +1,203 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import {
+  getFirestore,
+  collection,
+  doc,
+  getDoc,
+  setDoc,
+  deleteDoc,
+  serverTimestamp,
+  query,
+  orderBy,
+  onSnapshot,
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+const form = document.getElementById("addPlayerForm");
+const nameInput = document.getElementById("playerName");
+const codeInput = document.getElementById("playerCode");
+const addBtn = document.getElementById("addBtn");
+const statusEl = document.getElementById("status");
+const envEl = document.getElementById("env");
+const countEl = document.getElementById("count");
+const playersTbody = document.getElementById("playersTbody");
+
+const CODE_REGEX = /^[A-Z0-9]{3,16}$/;
+let firestoreDb;
+
+function setStatus(message, type = "info") {
+  statusEl.textContent = message;
+  if (!message) {
+    statusEl.removeAttribute("data-status");
+    statusEl.style.color = "";
+    return;
+  }
+  statusEl.dataset.status = type;
+  statusEl.style.color = type === "error" ? "#c0392b" : type === "success" ? "#2c662d" : "";
+}
+
+function toDisplayTime(timestamp) {
+  if (!timestamp) return "—";
+  try {
+    const date = timestamp.toDate();
+    return date.toLocaleString();
+  } catch (err) {
+    console.error("Failed to parse timestamp", err);
+    return "—";
+  }
+}
+
+async function initFirebase() {
+  try {
+    const response = await fetch("/__/firebase/init.json");
+    if (!response.ok) {
+      throw new Error(`Failed to load Firebase config: ${response.status}`);
+    }
+    const config = await response.json();
+    const app = initializeApp(config);
+    const db = getFirestore(app);
+    console.log(`[Firebase] initialized ${config.projectId}`);
+    envEl.textContent = `${config.projectId} · Firestore ready`;
+    return { db };
+  } catch (error) {
+    console.error(error);
+    envEl.textContent = "Failed to load Firebase";
+    setStatus("Could not initialise Firebase.", "error");
+    throw error;
+  }
+}
+
+function renderPlayers(snapshot) {
+  playersTbody.innerHTML = "";
+  let count = 0;
+  snapshot.forEach((docSnap) => {
+    count += 1;
+    const data = docSnap.data();
+    const tr = document.createElement("tr");
+
+    const nameTd = document.createElement("td");
+    nameTd.textContent = data.name || "—";
+    tr.append(nameTd);
+
+    const codeTd = document.createElement("td");
+    codeTd.textContent = data.code || docSnap.id;
+    tr.append(codeTd);
+
+    const createdTd = document.createElement("td");
+    createdTd.textContent = toDisplayTime(data.createdAt);
+    tr.append(createdTd);
+
+    const actionsTd = document.createElement("td");
+    const deleteBtn = document.createElement("button");
+    deleteBtn.type = "button";
+    deleteBtn.textContent = "Delete";
+    deleteBtn.dataset.code = docSnap.id;
+    deleteBtn.addEventListener("click", async () => {
+      const { code } = deleteBtn.dataset;
+      if (!code) return;
+      if (!confirm(`Delete player ${code}?`)) {
+        return;
+      }
+      setStatus("");
+      try {
+        await deleteDoc(doc(firestoreDb, "players", code));
+        setStatus(`Player ${code} deleted.`, "success");
+      } catch (error) {
+        console.error(error);
+        setStatus("Failed to delete player.", "error");
+      }
+    });
+    actionsTd.append(deleteBtn);
+    tr.append(actionsTd);
+
+    playersTbody.append(tr);
+  });
+  countEl.textContent = String(count);
+}
+
+function ensureUppercaseInput(event) {
+  const target = event.target;
+  if (target instanceof HTMLInputElement) {
+    const start = target.selectionStart;
+    const end = target.selectionEnd;
+    target.value = target.value.toUpperCase();
+    if (start !== null && end !== null) {
+      target.setSelectionRange(start, end);
+    }
+  }
+}
+
+(async () => {
+  let db;
+  try {
+    ({ db } = await initFirebase());
+  } catch (error) {
+    return;
+  }
+
+  firestoreDb = db;
+
+  codeInput.addEventListener("input", ensureUppercaseInput);
+
+  const playersRef = collection(db, "players");
+  const playersQuery = query(playersRef, orderBy("createdAt", "desc"));
+  onSnapshot(
+    playersQuery,
+    (snapshot) => {
+      renderPlayers(snapshot);
+    },
+    (error) => {
+      console.error(error);
+      setStatus("Failed to load players.", "error");
+    }
+  );
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    setStatus("");
+
+    const name = nameInput.value.trim();
+    let code = codeInput.value.trim().toUpperCase();
+    codeInput.value = code;
+
+    if (!name) {
+      setStatus("Player name is required.", "error");
+      nameInput.focus();
+      return;
+    }
+
+    if (!CODE_REGEX.test(code)) {
+      setStatus("Code must be 3–16 characters (A–Z, 0–9).", "error");
+      codeInput.focus();
+      return;
+    }
+
+    addBtn.disabled = true;
+
+    try {
+      const docRef = doc(db, "players", code);
+      const snapshot = await getDoc(docRef);
+      if (snapshot.exists()) {
+        setStatus("Code already exists.", "error");
+        addBtn.disabled = false;
+        codeInput.focus();
+        return;
+      }
+
+      await setDoc(docRef, {
+        name,
+        code,
+        active: true,
+        createdAt: serverTimestamp(),
+      });
+
+      setStatus(`Player ${name} (${code}) added.`, "success");
+      form.reset();
+      nameInput.focus();
+    } catch (error) {
+      console.error(error);
+      setStatus("Failed to add player.", "error");
+    } finally {
+      addBtn.disabled = false;
+    }
+  });
+})();

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,2 +1,153 @@
 <!doctype html>
-<h1>Admin Page</h1>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin — Players</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      body {
+        margin: 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 2vw + 1rem, 2.4rem);
+      }
+
+      form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: flex-end;
+      }
+
+      label {
+        display: flex;
+        flex-direction: column;
+        font-weight: 600;
+        gap: 0.25rem;
+      }
+
+      input[type="text"] {
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.5rem;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+        min-width: 220px;
+        font-size: 1rem;
+        text-transform: uppercase;
+      }
+
+      input[type="text"]:focus {
+        outline: 2px solid #4a90e2;
+        outline-offset: 1px;
+      }
+
+      #playerName {
+        text-transform: none;
+      }
+
+      button {
+        padding: 0.55rem 1.25rem;
+        border-radius: 999px;
+        border: none;
+        background: #4a90e2;
+        color: white;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      button[disabled] {
+        opacity: 0.6;
+        cursor: progress;
+      }
+
+      #status {
+        min-height: 1.5rem;
+        font-size: 0.95rem;
+      }
+
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+
+      th,
+      td {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+        text-align: left;
+      }
+
+      tbody tr:nth-child(odd) {
+        background-color: rgba(0, 0, 0, 0.04);
+      }
+
+      #env {
+        font-size: 0.9rem;
+        color: rgba(0, 0, 0, 0.6);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Admin — Players</h1>
+      <div id="env">Loading Firebase…</div>
+    </header>
+
+    <section aria-labelledby="form-heading">
+      <h2 id="form-heading" style="position:absolute;left:-9999px;">Add player</h2>
+      <form id="addPlayerForm">
+        <label>
+          Player name
+          <input id="playerName" type="text" name="playerName" autocomplete="off" required />
+        </label>
+        <label>
+          Player code
+          <input
+            id="playerCode"
+            type="text"
+            name="playerCode"
+            autocomplete="off"
+            required
+            inputmode="text"
+            minlength="3"
+            maxlength="16"
+            pattern="[A-Za-z0-9]{3,16}"
+          />
+        </label>
+        <button id="addBtn" type="submit">Add Player</button>
+      </form>
+      <div id="status" role="status" aria-live="polite"></div>
+    </section>
+
+    <section aria-labelledby="players-heading">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem;">
+        <h2 id="players-heading" style="margin:0;font-size:1.3rem;">Players</h2>
+        <span id="count">0</span>
+      </div>
+      <div style="overflow-x:auto;">
+        <table aria-describedby="players-heading">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Code</th>
+              <th scope="col">Created</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="playersTbody"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <script type="module" src="./admin.js"></script>
+  </body>
+</html>

--- a/public/lobby/index.html
+++ b/public/lobby/index.html
@@ -1,2 +1,114 @@
 <!doctype html>
-<h1>Lobby Page</h1>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Lobby</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      body {
+        margin: 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 2vw + 1rem, 2.4rem);
+      }
+
+      .panel {
+        padding: 1.5rem;
+        border-radius: 1rem;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        max-width: 380px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      input[type="text"] {
+        padding: 0.6rem 0.8rem;
+        border-radius: 0.6rem;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+        font-size: 1rem;
+        text-transform: uppercase;
+      }
+
+      input[type="text"]:focus {
+        outline: 2px solid #4a90e2;
+        outline-offset: 1px;
+      }
+
+      button {
+        padding: 0.6rem 1.2rem;
+        border-radius: 999px;
+        border: none;
+        background: #4a90e2;
+        color: white;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      button[disabled] {
+        opacity: 0.6;
+        cursor: progress;
+      }
+
+      #gateStatus {
+        min-height: 1.2rem;
+        font-size: 0.9rem;
+      }
+
+      #welcomeStrip {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      #lobbyContent {
+        padding: 1rem 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Lobby Page</h1>
+
+    <div id="gatePanel" class="panel" role="form" aria-labelledby="gateHeading">
+      <h2 id="gateHeading" style="margin:0;font-size:1.3rem;">Enter Code</h2>
+      <label for="gateCode">Player Code</label>
+      <input
+        id="gateCode"
+        type="text"
+        autocomplete="off"
+        placeholder="Enter your player code"
+        minlength="3"
+        maxlength="16"
+        pattern="[A-Za-z0-9]{3,16}"
+      />
+      <button id="gateBtn" type="button">Enter Lobby</button>
+      <div id="gateStatus" role="status" aria-live="polite"></div>
+    </div>
+
+    <div id="welcomeStrip" class="hidden">
+      <p style="margin:0;">Welcome, <span id="playerName"></span> (<span id="playerCode"></span>)</p>
+      <button id="changePlayer" type="button">Change Player</button>
+    </div>
+
+    <div id="lobbyContent" class="hidden">
+      <p>The lobby content is available once a valid player code is entered.</p>
+    </div>
+
+    <script type="module" src="./lobby.js"></script>
+  </body>
+</html>

--- a/public/lobby/lobby.js
+++ b/public/lobby/lobby.js
@@ -1,0 +1,176 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+const gatePanel = document.getElementById("gatePanel");
+const gateCodeInput = document.getElementById("gateCode");
+const gateBtn = document.getElementById("gateBtn");
+const gateStatus = document.getElementById("gateStatus");
+const welcomeStrip = document.getElementById("welcomeStrip");
+const playerNameEl = document.getElementById("playerName");
+const playerCodeEl = document.getElementById("playerCode");
+const changePlayerBtn = document.getElementById("changePlayer");
+const lobbyContent = document.getElementById("lobbyContent");
+
+const CODE_REGEX = /^[A-Z0-9]{3,16}$/;
+let firestoreDb;
+
+function setGateStatus(message, type = "info") {
+  gateStatus.textContent = message;
+  gateStatus.style.color =
+    type === "error" ? "#c0392b" : type === "success" ? "#2c662d" : "";
+}
+
+function ensureUppercaseInput(event) {
+  const target = event.target;
+  if (target instanceof HTMLInputElement) {
+    const { selectionStart, selectionEnd } = target;
+    target.value = target.value.toUpperCase();
+    if (selectionStart !== null && selectionEnd !== null) {
+      target.setSelectionRange(selectionStart, selectionEnd);
+    }
+  }
+}
+
+function setLobbyState(player) {
+  if (player) {
+    gatePanel.classList.add("hidden");
+    welcomeStrip.classList.remove("hidden");
+    lobbyContent.classList.remove("hidden");
+    playerNameEl.textContent = player.name || "Player";
+    playerCodeEl.textContent = player.code;
+  } else {
+    welcomeStrip.classList.add("hidden");
+    lobbyContent.classList.add("hidden");
+    gatePanel.classList.remove("hidden");
+    playerNameEl.textContent = "";
+    playerCodeEl.textContent = "";
+  }
+}
+
+function cachePlayer(player) {
+  if (player) {
+    localStorage.setItem("playerCode", player.code);
+    localStorage.setItem("playerName", player.name || "");
+  } else {
+    localStorage.removeItem("playerCode");
+    localStorage.removeItem("playerName");
+  }
+}
+
+async function initFirebase() {
+  const response = await fetch("/__/firebase/init.json");
+  if (!response.ok) {
+    throw new Error(`Failed to load Firebase config: ${response.status}`);
+  }
+  const config = await response.json();
+  const app = initializeApp(config);
+  firestoreDb = getFirestore(app);
+  console.log(`[Firebase] initialized ${config.projectId}`);
+}
+
+async function fetchPlayerByCode(code) {
+  if (!firestoreDb) return null;
+  const docRef = doc(firestoreDb, "players", code);
+  const snapshot = await getDoc(docRef);
+  if (!snapshot.exists()) {
+    return null;
+  }
+  const data = snapshot.data();
+  if (data.active === false) {
+    return null;
+  }
+  return {
+    name: data.name || "",
+    code: snapshot.id,
+    active: data.active !== false,
+  };
+}
+
+async function trySignInWithCode(code) {
+  const player = await fetchPlayerByCode(code);
+  if (!player) {
+    setGateStatus("Invalid or inactive code.", "error");
+    cachePlayer(null);
+    setLobbyState(null);
+    return false;
+  }
+
+  cachePlayer(player);
+  setLobbyState(player);
+  setGateStatus("");
+  return true;
+}
+
+(async () => {
+  try {
+    await initFirebase();
+  } catch (error) {
+    console.error(error);
+    setGateStatus("Unable to initialise lobby.", "error");
+    gateBtn.disabled = true;
+    return;
+  }
+
+  gateCodeInput.addEventListener("input", ensureUppercaseInput);
+
+  const storedCode = localStorage.getItem("playerCode");
+  if (storedCode) {
+    const normalized = storedCode.toUpperCase();
+    gateCodeInput.value = normalized;
+    try {
+      const player = await fetchPlayerByCode(normalized);
+      if (player) {
+        cachePlayer(player);
+        setLobbyState(player);
+        setGateStatus("");
+      } else {
+        cachePlayer(null);
+        setLobbyState(null);
+      }
+    } catch (error) {
+      console.error(error);
+      cachePlayer(null);
+      setLobbyState(null);
+      setGateStatus("Unable to verify stored code.", "error");
+    }
+  } else {
+    setLobbyState(null);
+  }
+
+  if (!storedCode || welcomeStrip.classList.contains("hidden")) {
+    gateCodeInput.focus();
+  }
+
+  gateBtn.addEventListener("click", async () => {
+    setGateStatus("");
+    let code = gateCodeInput.value.trim().toUpperCase();
+    gateCodeInput.value = code;
+
+    if (!CODE_REGEX.test(code)) {
+      setGateStatus("Enter a 3–16 character code (A–Z, 0–9).", "error");
+      gateCodeInput.focus();
+      return;
+    }
+
+    gateBtn.disabled = true;
+    try {
+      const success = await trySignInWithCode(code);
+      if (success) {
+        gateCodeInput.value = "";
+      }
+    } catch (error) {
+      console.error(error);
+      setGateStatus("Unable to verify code.", "error");
+    } finally {
+      gateBtn.disabled = false;
+    }
+  });
+
+  changePlayerBtn.addEventListener("click", () => {
+    cachePlayer(null);
+    setLobbyState(null);
+    gateCodeInput.value = "";
+    setGateStatus("");
+    gateCodeInput.focus();
+  });
+})();


### PR DESCRIPTION
## Summary
- replace the admin page with a Firestore-backed player management UI for creating and deleting players by code
- add front-end gating in the lobby that requires a valid player code before revealing the lobby content
- update the deployment workflow verification to look for the new admin heading text

## Testing
- not run (front-end only)

------
https://chatgpt.com/codex/tasks/task_e_68ccaf22cd58832e8964ca1b9af59829