### PR TITLE
Add admin CRUD management and diagnostics

### DIFF
--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -1,4 +1,4 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import { initializeApp, getApps, getApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
 import {
   getFirestore,
   collection,
@@ -12,27 +12,115 @@ import {
   onSnapshot,
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
-const form = document.getElementById("addPlayerForm");
-const nameInput = document.getElementById("playerName");
-const codeInput = document.getElementById("playerCode");
-const addBtn = document.getElementById("addBtn");
-const statusEl = document.getElementById("status");
+const CODE_REGEX = /^[A-Z0-9]{3,16}$/;
+const LOG_KEY = "admin.debugLog";
+const MAX_LOG_LINES = 500;
+
 const envEl = document.getElementById("env");
-const countEl = document.getElementById("count");
+const debugLogEl = document.getElementById("debugLog");
+const copyLogBtn = document.getElementById("copyLog");
+const clearLogBtn = document.getElementById("clearLog");
+const healthInitBtn = document.getElementById("healthInit");
+const healthPingBtn = document.getElementById("healthPing");
+const healthReadBtn = document.getElementById("healthRead");
+const healthWriteBtn = document.getElementById("healthWrite");
+
+const playerForm = document.getElementById("playerForm");
+const playerNameInput = document.getElementById("playerName");
+const playerCodeInput = document.getElementById("playerCode");
+const playerAddBtn = document.getElementById("playerAddBtn");
+const playerStatusEl = document.getElementById("playerStatus");
+const playerCountEl = document.getElementById("playerCount");
 const playersTbody = document.getElementById("playersTbody");
 
-const CODE_REGEX = /^[A-Z0-9]{3,16}$/;
-let firestoreDb;
+const arenaForm = document.getElementById("arenaForm");
+const arenaNameInput = document.getElementById("arenaName");
+const arenaCodeInput = document.getElementById("arenaCode");
+const arenaAddBtn = document.getElementById("arenaAddBtn");
+const arenaStatusEl = document.getElementById("arenaStatus");
+const arenaCountEl = document.getElementById("arenaCount");
+const arenasTbody = document.getElementById("arenasTbody");
 
-function setStatus(message, type = "info") {
-  statusEl.textContent = message;
+let firebaseConfig = null;
+let firebaseApp = null;
+let firestoreDb = null;
+let unsubscribePlayers = null;
+let unsubscribeArenas = null;
+let logLines = [];
+
+function loadLogFromSession() {
+  try {
+    const stored = sessionStorage.getItem(LOG_KEY);
+    if (!stored) {
+      logLines = [];
+      return;
+    }
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed)) {
+      logLines = parsed.slice(-MAX_LOG_LINES);
+    } else {
+      logLines = [];
+    }
+  } catch (error) {
+    console.warn("Failed to restore debug log", error);
+    logLines = [];
+  }
+}
+
+function persistLog() {
+  try {
+    sessionStorage.setItem(LOG_KEY, JSON.stringify(logLines.slice(-MAX_LOG_LINES)));
+  } catch (error) {
+    console.warn("Failed to persist debug log", error);
+  }
+}
+
+function renderLog() {
+  debugLogEl.value = logLines.join("\n");
+  debugLogEl.scrollTop = debugLogEl.scrollHeight;
+}
+
+function logEvent(event, details) {
+  const timestamp = new Date().toISOString();
+  const serialized =
+    details && Object.keys(details).length > 0
+      ? `${timestamp} ${event} ${JSON.stringify(details)}`
+      : `${timestamp} ${event}`;
+  logLines.push(serialized);
+  if (logLines.length > MAX_LOG_LINES) {
+    logLines = logLines.slice(-MAX_LOG_LINES);
+  }
+  persistLog();
+  renderLog();
+  console.log(serialized);
+}
+
+function setStatus(targetEl, message, type = "info") {
+  targetEl.textContent = message;
+  targetEl.dataset.status = type;
   if (!message) {
-    statusEl.removeAttribute("data-status");
-    statusEl.style.color = "";
+    targetEl.removeAttribute("data-status");
+    targetEl.style.color = "";
     return;
   }
-  statusEl.dataset.status = type;
-  statusEl.style.color = type === "error" ? "#c0392b" : type === "success" ? "#2c662d" : "";
+  if (type === "error") {
+    targetEl.style.color = "#c0392b";
+  } else if (type === "success") {
+    targetEl.style.color = "#2c662d";
+  } else {
+    targetEl.style.color = "";
+  }
+}
+
+function ensureUppercaseInput(event) {
+  const target = event.target;
+  if (target instanceof HTMLInputElement) {
+    const { selectionStart, selectionEnd } = target;
+    target.value = target.value.toUpperCase();
+    if (selectionStart !== null && selectionEnd !== null) {
+      target.setSelectionRange(selectionStart, selectionEnd);
+    }
+  }
 }
 
 function toDisplayTime(timestamp) {
@@ -40,164 +128,394 @@ function toDisplayTime(timestamp) {
   try {
     const date = timestamp.toDate();
     return date.toLocaleString();
-  } catch (err) {
-    console.error("Failed to parse timestamp", err);
+  } catch (error) {
+    logEvent("timestamp.parse.err", { message: error.message });
     return "—";
   }
 }
 
-async function initFirebase() {
+async function fetchFirebaseConfig() {
+  logEvent("config.fetch.start");
+  let response;
   try {
-    const response = await fetch("/__/firebase/init.json");
-    if (!response.ok) {
-      throw new Error(`Failed to load Firebase config: ${response.status}`);
-    }
-    const config = await response.json();
-    const app = initializeApp(config);
-    const db = getFirestore(app);
-    console.log(`[Firebase] initialized ${config.projectId}`);
-    envEl.textContent = `${config.projectId} · Firestore ready`;
-    return { db };
+    response = await fetch("/__/firebase/init.json", { cache: "no-store" });
   } catch (error) {
-    console.error(error);
+    logEvent("config.fetch.err", { message: error.message, code: error.code });
+    throw error;
+  }
+
+  if (!response.ok) {
+    const error = new Error(`Failed to load Firebase config: ${response.status}`);
+    logEvent("config.fetch.err", { status: response.status, statusText: response.statusText });
+    throw error;
+  }
+
+  const config = await response.json();
+  logEvent("config.fetch.ok", { projectId: config.projectId });
+  return config;
+}
+
+async function initialiseFirebase({ forceFetchConfig = false } = {}) {
+  try {
+    if (!firebaseConfig || forceFetchConfig) {
+      firebaseConfig = await fetchFirebaseConfig();
+    }
+
+    if (!firebaseApp) {
+      if (getApps().length === 0) {
+        firebaseApp = initializeApp(firebaseConfig);
+        logEvent("app.init.ok", { projectId: firebaseConfig.projectId });
+        console.log(`[Firebase] initialized ${firebaseConfig.projectId}`);
+      } else {
+        firebaseApp = getApp();
+        logEvent("app.init.reuse", { projectId: firebaseConfig.projectId });
+      }
+    }
+
+    firestoreDb = getFirestore(firebaseApp);
+    logEvent("firestore.ready", { projectId: firebaseConfig.projectId });
+    envEl.textContent = `${firebaseConfig.projectId} · Firestore ready`;
+    return firestoreDb;
+  } catch (error) {
     envEl.textContent = "Failed to load Firebase";
-    setStatus("Could not initialise Firebase.", "error");
+    setStatus(playerStatusEl, "Could not initialise Firebase.", "error");
+    setStatus(arenaStatusEl, "Could not initialise Firebase.", "error");
+    logEvent("app.init.err", { message: error.message, code: error.code });
     throw error;
   }
 }
 
-function renderPlayers(snapshot) {
-  playersTbody.innerHTML = "";
-  let count = 0;
-  snapshot.forEach((docSnap) => {
-    count += 1;
-    const data = docSnap.data();
-    const tr = document.createElement("tr");
+function renderCollectionRow({ name, code, createdAt }, onDelete) {
+  const tr = document.createElement("tr");
 
-    const nameTd = document.createElement("td");
-    nameTd.textContent = data.name || "—";
-    tr.append(nameTd);
+  const nameTd = document.createElement("td");
+  nameTd.textContent = name || "—";
+  tr.appendChild(nameTd);
 
-    const codeTd = document.createElement("td");
-    codeTd.textContent = data.code || docSnap.id;
-    tr.append(codeTd);
+  const codeTd = document.createElement("td");
+  codeTd.textContent = code;
+  tr.appendChild(codeTd);
 
-    const createdTd = document.createElement("td");
-    createdTd.textContent = toDisplayTime(data.createdAt);
-    tr.append(createdTd);
+  const createdTd = document.createElement("td");
+  createdTd.textContent = toDisplayTime(createdAt);
+  tr.appendChild(createdTd);
 
-    const actionsTd = document.createElement("td");
-    const deleteBtn = document.createElement("button");
-    deleteBtn.type = "button";
-    deleteBtn.textContent = "Delete";
-    deleteBtn.dataset.code = docSnap.id;
-    deleteBtn.addEventListener("click", async () => {
-      const { code } = deleteBtn.dataset;
-      if (!code) return;
-      if (!confirm(`Delete player ${code}?`)) {
-        return;
-      }
-      setStatus("");
-      try {
-        await deleteDoc(doc(firestoreDb, "players", code));
-        setStatus(`Player ${code} deleted.`, "success");
-      } catch (error) {
-        console.error(error);
-        setStatus("Failed to delete player.", "error");
-      }
-    });
-    actionsTd.append(deleteBtn);
-    tr.append(actionsTd);
+  const actionsTd = document.createElement("td");
+  const deleteBtn = document.createElement("button");
+  deleteBtn.type = "button";
+  deleteBtn.textContent = "Delete";
+  deleteBtn.addEventListener("click", onDelete);
+  actionsTd.appendChild(deleteBtn);
+  tr.appendChild(actionsTd);
 
-    playersTbody.append(tr);
-  });
-  countEl.textContent = String(count);
+  return tr;
 }
 
-function ensureUppercaseInput(event) {
-  const target = event.target;
-  if (target instanceof HTMLInputElement) {
-    const start = target.selectionStart;
-    const end = target.selectionEnd;
-    target.value = target.value.toUpperCase();
-    if (start !== null && end !== null) {
-      target.setSelectionRange(start, end);
-    }
-  }
-}
-
-(async () => {
-  let db;
-  try {
-    ({ db } = await initFirebase());
-  } catch (error) {
-    return;
-  }
-
-  firestoreDb = db;
-
-  codeInput.addEventListener("input", ensureUppercaseInput);
-
+function subscribeToPlayers(db) {
+  if (unsubscribePlayers) unsubscribePlayers();
   const playersRef = collection(db, "players");
   const playersQuery = query(playersRef, orderBy("createdAt", "desc"));
-  onSnapshot(
+  unsubscribePlayers = onSnapshot(
     playersQuery,
     (snapshot) => {
-      renderPlayers(snapshot);
+      playersTbody.innerHTML = "";
+      let count = 0;
+      snapshot.forEach((docSnap) => {
+        count += 1;
+        const data = docSnap.data();
+        const row = renderCollectionRow(
+          {
+            name: data.name,
+            code: data.code || docSnap.id,
+            createdAt: data.createdAt,
+          },
+          () => handlePlayerDelete(docSnap.id)
+        );
+        playersTbody.appendChild(row);
+      });
+      playerCountEl.textContent = String(count);
+      logEvent("players.snapshot.update", { size: snapshot.size });
     },
     (error) => {
-      console.error(error);
-      setStatus("Failed to load players.", "error");
+      setStatus(playerStatusEl, "Failed to load players.", "error");
+      logEvent("players.snapshot.err", { message: error.message, code: error.code });
     }
   );
+}
 
-  form.addEventListener("submit", async (event) => {
+function subscribeToArenas(db) {
+  if (unsubscribeArenas) unsubscribeArenas();
+  const arenasRef = collection(db, "arenas");
+  const arenasQuery = query(arenasRef, orderBy("createdAt", "desc"));
+  unsubscribeArenas = onSnapshot(
+    arenasQuery,
+    (snapshot) => {
+      arenasTbody.innerHTML = "";
+      let count = 0;
+      snapshot.forEach((docSnap) => {
+        count += 1;
+        const data = docSnap.data();
+        const row = renderCollectionRow(
+          {
+            name: data.name,
+            code: data.code || docSnap.id,
+            createdAt: data.createdAt,
+          },
+          () => handleArenaDelete(docSnap.id)
+        );
+        arenasTbody.appendChild(row);
+      });
+      arenaCountEl.textContent = String(count);
+      logEvent("arenas.snapshot.update", { size: snapshot.size });
+    },
+    (error) => {
+      setStatus(arenaStatusEl, "Failed to load arenas.", "error");
+      logEvent("arenas.snapshot.err", { message: error.message, code: error.code });
+    }
+  );
+}
+
+async function handlePlayerDelete(code) {
+  if (!firestoreDb) return;
+  if (!confirm(`Delete player ${code}?`)) {
+    return;
+  }
+  logEvent("players.delete.confirm", { code });
+  try {
+    await deleteDoc(doc(firestoreDb, "players", code));
+    setStatus(playerStatusEl, `Player ${code} deleted.`, "success");
+    logEvent("players.delete.ok", { code });
+  } catch (error) {
+    setStatus(playerStatusEl, "Failed to delete player.", "error");
+    logEvent("players.delete.err", { code, errCode: error.code, errMsg: error.message });
+  }
+}
+
+async function handleArenaDelete(code) {
+  if (!firestoreDb) return;
+  if (!confirm(`Delete arena ${code}?`)) {
+    return;
+  }
+  logEvent("arenas.delete.confirm", { code });
+  try {
+    await deleteDoc(doc(firestoreDb, "arenas", code));
+    setStatus(arenaStatusEl, `Arena ${code} deleted.`, "success");
+    logEvent("arenas.delete.ok", { code });
+  } catch (error) {
+    setStatus(arenaStatusEl, "Failed to delete arena.", "error");
+    logEvent("arenas.delete.err", { code, errCode: error.code, errMsg: error.message });
+  }
+}
+
+function registerPlayerForm(db) {
+  playerCodeInput.addEventListener("input", ensureUppercaseInput);
+  playerForm.addEventListener("submit", async (event) => {
     event.preventDefault();
-    setStatus("");
+    setStatus(playerStatusEl, "");
 
-    const name = nameInput.value.trim();
-    let code = codeInput.value.trim().toUpperCase();
-    codeInput.value = code;
+    const name = playerNameInput.value.trim();
+    const code = playerCodeInput.value.trim().toUpperCase();
+    playerCodeInput.value = code;
 
     if (!name) {
-      setStatus("Player name is required.", "error");
-      nameInput.focus();
+      setStatus(playerStatusEl, "Player name is required.", "error");
+      playerNameInput.focus();
       return;
     }
-
     if (!CODE_REGEX.test(code)) {
-      setStatus("Code must be 3–16 characters (A–Z, 0–9).", "error");
-      codeInput.focus();
+      setStatus(playerStatusEl, "Code must be 3–16 characters (A–Z, 0–9).", "error");
+      playerCodeInput.focus();
       return;
     }
 
-    addBtn.disabled = true;
+    playerAddBtn.disabled = true;
+    logEvent("players.add.submit", { code });
 
     try {
-      const docRef = doc(db, "players", code);
-      const snapshot = await getDoc(docRef);
+      const playerRef = doc(db, "players", code);
+      const snapshot = await getDoc(playerRef);
       if (snapshot.exists()) {
-        setStatus("Code already exists.", "error");
-        addBtn.disabled = false;
-        codeInput.focus();
+        setStatus(playerStatusEl, "Code already exists.", "error");
+        logEvent("players.add.exists", { code });
+        playerAddBtn.disabled = false;
+        playerCodeInput.focus();
         return;
       }
 
-      await setDoc(docRef, {
+      await setDoc(playerRef, {
+        name,
+        code,
+        active: true,
+        createdAt: serverTimestamp(),
+        currentRoomId: null, // Future: enforce single-room membership per player
+      });
+
+      setStatus(playerStatusEl, `Player ${name} (${code}) added.`, "success");
+      logEvent("players.add.ok", { code });
+      playerForm.reset();
+      playerNameInput.focus();
+    } catch (error) {
+      setStatus(playerStatusEl, "Failed to add player.", "error");
+      logEvent("players.add.err", { code, errCode: error.code, errMsg: error.message });
+    } finally {
+      playerAddBtn.disabled = false;
+    }
+  });
+}
+
+function registerArenaForm(db) {
+  arenaCodeInput.addEventListener("input", ensureUppercaseInput);
+  arenaForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    setStatus(arenaStatusEl, "");
+
+    const name = arenaNameInput.value.trim();
+    const code = arenaCodeInput.value.trim().toUpperCase();
+    arenaCodeInput.value = code;
+
+    if (!name) {
+      setStatus(arenaStatusEl, "Arena name is required.", "error");
+      arenaNameInput.focus();
+      return;
+    }
+    if (!CODE_REGEX.test(code)) {
+      setStatus(arenaStatusEl, "Code must be 3–16 characters (A–Z, 0–9).", "error");
+      arenaCodeInput.focus();
+      return;
+    }
+
+    arenaAddBtn.disabled = true;
+    logEvent("arenas.add.submit", { code });
+
+    try {
+      const arenaRef = doc(db, "arenas", code);
+      const snapshot = await getDoc(arenaRef);
+      if (snapshot.exists()) {
+        setStatus(arenaStatusEl, "Code already exists.", "error");
+        logEvent("arenas.add.exists", { code });
+        arenaAddBtn.disabled = false;
+        arenaCodeInput.focus();
+        return;
+      }
+
+      await setDoc(arenaRef, {
         name,
         code,
         active: true,
         createdAt: serverTimestamp(),
       });
 
-      setStatus(`Player ${name} (${code}) added.`, "success");
-      form.reset();
-      nameInput.focus();
+      setStatus(arenaStatusEl, `Arena ${name} (${code}) added.`, "success");
+      logEvent("arenas.add.ok", { code });
+      arenaForm.reset();
+      arenaNameInput.focus();
     } catch (error) {
-      console.error(error);
-      setStatus("Failed to add player.", "error");
+      setStatus(arenaStatusEl, "Failed to add arena.", "error");
+      logEvent("arenas.add.err", { code, errCode: error.code, errMsg: error.message });
     } finally {
-      addBtn.disabled = false;
+      arenaAddBtn.disabled = false;
     }
   });
-})();
+}
+
+async function runHealthInit() {
+  try {
+    await initialiseFirebase({ forceFetchConfig: true });
+    logEvent("health.init.ok", { projectId: firebaseConfig?.projectId });
+  } catch (error) {
+    logEvent("health.init.err", { message: error.message, code: error.code });
+  }
+}
+
+async function runHealthPing() {
+  const routes = ["/", "/lobby", "/admin"];
+  for (const route of routes) {
+    try {
+      const response = await fetch(route, { cache: "no-store" });
+      logEvent("health.ping", { route, status: response.status });
+    } catch (error) {
+      logEvent("health.ping.err", { route, message: error.message, code: error.code });
+    }
+  }
+}
+
+async function runHealthRead() {
+  if (!firestoreDb) {
+    logEvent("health.read.err", { message: "Firestore not initialised" });
+    return;
+  }
+  try {
+    const docRef = doc(firestoreDb, "players", "__NON_EXISTENT__");
+    const snapshot = await getDoc(docRef);
+    logEvent("health.read.ok", { exists: snapshot.exists() });
+  } catch (error) {
+    logEvent("health.read.err", { message: error.message, code: error.code });
+  }
+}
+
+async function runHealthWrite() {
+  if (!firestoreDb) {
+    logEvent("health.write.err", { message: "Firestore not initialised" });
+    return;
+  }
+  try {
+    const diagRef = doc(firestoreDb, "diag", "WRITE_TEST");
+    await setDoc(diagRef, { ts: serverTimestamp(), rand: Math.random() });
+    logEvent("health.write.ok", {});
+  } catch (error) {
+    logEvent("health.write.err", { code: error.code, message: error.message });
+  }
+}
+
+function registerDiagnostics() {
+  copyLogBtn.addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText(debugLogEl.value);
+      logEvent("debug.copy.ok");
+    } catch (error) {
+      logEvent("debug.copy.err", { message: error.message });
+    }
+  });
+
+  clearLogBtn.addEventListener("click", () => {
+    logLines = [];
+    persistLog();
+    renderLog();
+    console.log(`${new Date().toISOString()} debug.clear.ok`);
+  });
+
+  healthInitBtn.addEventListener("click", () => {
+    runHealthInit();
+  });
+  healthPingBtn.addEventListener("click", () => {
+    runHealthPing();
+  });
+  healthReadBtn.addEventListener("click", () => {
+    runHealthRead();
+  });
+  healthWriteBtn.addEventListener("click", () => {
+    runHealthWrite();
+  });
+}
+
+async function main() {
+  loadLogFromSession();
+  renderLog();
+  logEvent("admin.page.load", {});
+
+  try {
+    const db = await initialiseFirebase();
+    registerPlayerForm(db);
+    registerArenaForm(db);
+    subscribeToPlayers(db);
+    subscribeToArenas(db);
+  } catch (error) {
+    logEvent("admin.init.failed", { message: error.message });
+  }
+
+  registerDiagnostics();
+}
+
+main().catch((error) => {
+  logEvent("admin.fatal", { message: error.message });
+});

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Admin — Players</title>
+    <title>Admin Page</title>
     <style>
       :root {
         color-scheme: light dark;
@@ -14,12 +14,24 @@
         margin: 2rem;
         display: flex;
         flex-direction: column;
-        gap: 1.5rem;
+        gap: 2.5rem;
+        max-width: 1100px;
       }
 
       h1 {
-        margin: 0;
+        margin: 0 0 0.25rem;
         font-size: clamp(1.8rem, 2vw + 1rem, 2.4rem);
+      }
+
+      h2 {
+        margin: 0;
+        font-size: clamp(1.35rem, 1vw + 1rem, 1.8rem);
+      }
+
+      section {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
       }
 
       form {
@@ -50,7 +62,8 @@
         outline-offset: 1px;
       }
 
-      #playerName {
+      #playerName,
+      #arenaName {
         text-transform: none;
       }
 
@@ -69,7 +82,7 @@
         cursor: progress;
       }
 
-      #status {
+      .status {
         min-height: 1.5rem;
         font-size: 0.95rem;
       }
@@ -77,6 +90,7 @@
       table {
         border-collapse: collapse;
         width: 100%;
+        background: rgba(255, 255, 255, 0.8);
       }
 
       th,
@@ -84,6 +98,7 @@
         padding: 0.5rem 0.75rem;
         border-bottom: 1px solid rgba(0, 0, 0, 0.1);
         text-align: left;
+        vertical-align: middle;
       }
 
       tbody tr:nth-child(odd) {
@@ -94,17 +109,57 @@
         font-size: 0.9rem;
         color: rgba(0, 0, 0, 0.6);
       }
+
+      .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      .section-header span {
+        font-weight: 600;
+      }
+
+      #diagnostics button {
+        background: #2d7d46;
+      }
+
+      #diagnostics button.secondary {
+        background: #4a90e2;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 220px;
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        font-size: 0.85rem;
+        padding: 0.75rem;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        resize: vertical;
+      }
+
+      .log-controls {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
     </style>
   </head>
   <body>
     <header>
-      <h1>Admin — Players</h1>
+      <h1>Admin Page</h1>
       <div id="env">Loading Firebase…</div>
     </header>
 
-    <section aria-labelledby="form-heading">
-      <h2 id="form-heading" style="position:absolute;left:-9999px;">Add player</h2>
-      <form id="addPlayerForm">
+    <section id="players">
+      <div class="section-header">
+        <h2>Admin — Players</h2>
+        <span>Total: <span id="playerCount">0</span></span>
+      </div>
+      <form id="playerForm">
         <label>
           Player name
           <input id="playerName" type="text" name="playerName" autocomplete="off" required />
@@ -123,18 +178,11 @@
             pattern="[A-Za-z0-9]{3,16}"
           />
         </label>
-        <button id="addBtn" type="submit">Add Player</button>
+        <button id="playerAddBtn" type="submit">Add Player</button>
       </form>
-      <div id="status" role="status" aria-live="polite"></div>
-    </section>
-
-    <section aria-labelledby="players-heading">
-      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem;">
-        <h2 id="players-heading" style="margin:0;font-size:1.3rem;">Players</h2>
-        <span id="count">0</span>
-      </div>
-      <div style="overflow-x:auto;">
-        <table aria-describedby="players-heading">
+      <div id="playerStatus" class="status" role="status" aria-live="polite"></div>
+      <div style="overflow-x: auto">
+        <table aria-label="Players table">
           <thead>
             <tr>
               <th scope="col">Name</th>
@@ -146,6 +194,65 @@
           <tbody id="playersTbody"></tbody>
         </table>
       </div>
+    </section>
+
+    <section id="arenas">
+      <div class="section-header">
+        <h2>Admin — Arenas</h2>
+        <span>Total: <span id="arenaCount">0</span></span>
+      </div>
+      <form id="arenaForm">
+        <label>
+          Arena name
+          <input id="arenaName" type="text" name="arenaName" autocomplete="off" required />
+        </label>
+        <label>
+          Arena code
+          <input
+            id="arenaCode"
+            type="text"
+            name="arenaCode"
+            autocomplete="off"
+            required
+            inputmode="text"
+            minlength="3"
+            maxlength="16"
+            pattern="[A-Za-z0-9]{3,16}"
+          />
+        </label>
+        <button id="arenaAddBtn" type="submit">Add Arena</button>
+      </form>
+      <div id="arenaStatus" class="status" role="status" aria-live="polite"></div>
+      <div style="overflow-x: auto">
+        <table aria-label="Arenas table">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Code</th>
+              <th scope="col">Created</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="arenasTbody"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="diagnostics">
+      <div class="section-header">
+        <h2>Diagnostics</h2>
+      </div>
+      <div class="log-controls">
+        <button id="healthInit" type="button">Health: Re-init Firebase</button>
+        <button id="healthPing" type="button">Health: Ping Routes</button>
+        <button id="healthRead" type="button">Health: Read Test</button>
+        <button id="healthWrite" type="button">Health: Write Test</button>
+      </div>
+      <div class="log-controls">
+        <button id="copyLog" class="secondary" type="button">Copy Log</button>
+        <button id="clearLog" class="secondary" type="button">Clear Log</button>
+      </div>
+      <textarea id="debugLog" readonly></textarea>
     </section>
 
     <script type="module" src="./admin.js"></script>


### PR DESCRIPTION
## Summary
- redesign the admin page to separate player and arena management and surface diagnostics controls and log tools
- implement Firestore-backed CRUD flows, persistent debug logging, and health check utilities for players, arenas, and diagnostics

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccb406a2f4832eb26603172af5afa7